### PR TITLE
python3 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,14 @@ CUDA_INCLUDES = -I$(CUDA_PATH)/include
 OPENCV_LDFLAGS = $(CUDA_LDFLAGS)
 OPENCV_LIBS = $$(pkg-config --libs opencv)
 OPENCV_INCLUDES = $$(pkg-config --cflags opencv) $(CUDA_INCLUDES)
-BOOST_LIBS = -lboost_python
-PYTHON_LIBS = $$(pkg-config --libs python2)
-PYTHON_INCLUDES = $$(pkg-config --cflags python2)
+PYTHON_VER = 2
+ifeq ($(PYTHON_VER), 2)
+  BOOST_LIBS = -lboost_python
+else
+  BOOST_LIBS = -lboost_python$(PYTHON_VER)
+endif
+PYTHON_LIBS = $$(pkg-config --libs python$(PYTHON_VER))
+PYTHON_INCLUDES = $$(pkg-config --cflags python$(PYTHON_VER))
 
 TARGET = examples
 
@@ -34,4 +39,4 @@ clean:
 	rm -f *.o *.so
 
 test:
-	env python2 -m test
+	env python$(PYTHON_VER) -m test

--- a/conversion.cpp
+++ b/conversion.cpp
@@ -164,7 +164,7 @@ cv::Mat NDArrayConverter::toMat(const PyObject *o)
     const npy_intp* _sizes = PyArray_DIMS(o);
     const npy_intp* _strides = PyArray_STRIDES(o);
     bool transposed = false;
-    
+
     for(int i = 0; i < ndims; i++)
     {
         size[i] = (int)_sizes[i];

--- a/conversion.h
+++ b/conversion.h
@@ -7,6 +7,9 @@
 #include <opencv2/core/core.hpp>
 #include "numpy/ndarrayobject.h"
 
+#define NUMPY_IMPORT_ARRAY_RETVAL
+
+
 static PyObject* opencv_error = 0;
 
 static int failmsg(const char *fmt, ...);


### PR DESCRIPTION
This patch set provides support to use python3. 

When building with python3, the numpy headers has the `import_array()` macro return a value and this causes a compilation error because the functions it resides it are void and shouldn't have one. To work around this we can just override the return value macro, `NUMPY_IMPORT_ARRAY_RETVAL`, by re-defining it to nothing so the return statement has no effect. This is the only change needed to the code as far as I can tell. 

Set `PYTHON_VER=3` before building and testing.
