### PR TITLE
Add CMake build for opencv-ndarray-conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,3 +23,8 @@ target_link_libraries(examples ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} ${OpenCV_L
 # don't prepend wrapper library name with lib
 set_target_properties(examples PROPERTIES PREFIX "" )
 
+if(WIN32)
+  set_target_properties(examples PROPERTIES SUFFIX ".pyd")
+elseif (APPLE)
+  set_target_properties(examples PROPERTIES SUFFIX ".so")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+project (opencv-ndarray-conversion)
+cmake_minimum_required (VERSION 2.6.0)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -std=c++11")
+
+# Find necessary packages
+find_package( PythonLibs 2.7 REQUIRED )
+include_directories( ${PYTHON_INCLUDE_DIRS} )
+
+find_package( Boost COMPONENTS python REQUIRED )
+include_directories( ${Boost_INCLUDE_DIR} )
+
+find_package( OpenCV REQUIRED )
+include_directories( ${OpenCV_INCLUDE_DIR} )
+
+# Build our library
+add_library(conversion SHARED conversion.cpp )
+target_link_libraries(conversion ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} ${OpenCV_LIBRARIES})
+
+# Define the wrapper library that wraps our library
+add_library(examples SHARED examples.cpp )
+target_link_libraries(examples ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} ${OpenCV_LIBRARIES} examples conversion)
+# don't prepend wrapper library name with lib
+set_target_properties(examples PROPERTIES PREFIX "" )
+

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ a test-suite to test (and demonstrate) the converter.
 Building with CMake (Ubuntu)
 ---------------------
 After installing [Boost::Python][1] and [NumPy][2](maybe the devel package),
+
     $ mkdir build 
     $ cd build
     $ cmake ..

--- a/README.md
+++ b/README.md
@@ -65,3 +65,11 @@ a test-suite to test (and demonstrate) the converter.
 [1]: http://www.boost.org/doc/libs/1_53_0/libs/python/doc/index.html
 [2]: http://www.numpy.org/
 
+Building with CMake (Ubuntu)
+---------------------
+After installing [Boost::Python][1] and [NumPy][2](maybe the devel package),
+    $ mkdir build 
+    $ cd build
+    $ cmake ..
+    $ make
+


### PR DESCRIPTION
The CMakeList.txt has been tested under ubuntu. 
For Mac OSX, CMake will produce a  examples.dylib fie instead of examples.so. 

Any idea to improve so that it will work on both platform?
